### PR TITLE
make the enterAnimation and exitAnimation props optional

### DIFF
--- a/src/PageTransition.tsx
+++ b/src/PageTransition.tsx
@@ -7,8 +7,8 @@ import { PageTransitionWrapper } from './PageTransitionWrapper';
 
 interface Props {
   children: React.ReactNode;
-  enterAnimation: string | { name: string; delay: Number; onTop: Boolean };
-  exitAnimation: string | { name: string; delay: Number; onTop: Boolean };
+  enterAnimation?: string | { name: string; delay: Number; onTop: Boolean };
+  exitAnimation?: string | { name: string; delay: Number; onTop: Boolean };
   preset: string;
   transitionKey: string;
 }


### PR DESCRIPTION
This PR fixes the types on Props for PageTransition. The **enterAnimation** and **exitAnimation** are optional but still required from Typescript types.